### PR TITLE
Fix duplicated headers overwriting original inputs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@advanced-rest-client/arc-headers",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@advanced-rest-client/arc-headers",
   "description": "A module that contains UI and logic for handle HTTP headers in an HTTP request and request editors.",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/HeadersParser.js
+++ b/src/HeadersParser.js
@@ -22,7 +22,7 @@ export class HeadersParser {
         return;
       }
       if (!(header.name in _tmp)) {
-        _tmp[header.name] = header;
+        _tmp[header.name] = { ...header };
         return;
       }
       if (header.value) {

--- a/test/HeadersParser.test.js
+++ b/test/HeadersParser.test.js
@@ -31,6 +31,31 @@ describe('HeadersParser', () => {
       const filtered = HeadersParser.unique(headers);
       assert.deepEqual(filtered, ref);
     });
+
+    it('does not overwrite original inputs when duplicate headers provided', () => {
+      const headers = [
+        {
+          name: 'x-test',
+          value: 'value 1',
+        },
+        {
+          name: 'x-test',
+          value: 'value 2',
+        },
+      ];
+      const expected = [
+        {
+          name: 'x-test',
+          value: 'value 1',
+        },
+        {
+          name: 'x-test',
+          value: 'value 2',
+        },
+      ];
+      HeadersParser.unique(headers);
+      assert.deepEqual(headers, expected);
+    })
   });
 
   describe('toJSON()', () => {


### PR DESCRIPTION
When calling the `unique` function, the original inputs supplied were being overwritten with the squashed value.

Make copy of object so as to avoid this