### PR TITLE
Fix `replace` with empty header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ $RECYCLE.BIN/
 
 node_modules
 coverage
+.idea

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@advanced-rest-client/arc-headers",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@advanced-rest-client/arc-headers",
   "description": "A module that contains UI and logic for handle HTTP headers in an HTTP request and request editors.",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/HeadersParser.js
+++ b/src/HeadersParser.js
@@ -45,7 +45,7 @@ export class HeadersParser {
     }
     return HeadersParser.headersToJSON(headers);
   }
-  
+
   /**
    * Parse headers string to array of objects.
    * See `#toJSON` for more info.
@@ -185,6 +185,28 @@ export class HeadersParser {
     return parts.join('\n');
   }
 
+  static toStringAsIs(input) {
+    if (typeof input === 'string') {
+      return input;
+    }
+    let headers = input;
+    if (!Array.isArray(headers)) {
+      headers = HeadersParser.toJSON(headers);
+    }
+    if (headers.length === 0) {
+      return '';
+    }
+    headers = HeadersParser.unique(headers);
+    const parts = [];
+    headers.forEach((item) => {
+      if (!item.name && !item.value) {
+        return;
+      }
+      parts.push(HeadersParser.itemToString(item));
+    });
+    return parts.join('\n');
+  }
+
   /**
    * Finds and returns the value of the Content-Type value header.
    *
@@ -254,7 +276,7 @@ export class HeadersParser {
       return headers;
     }
     if (origType === 'string') {
-      return HeadersParser.toString(headers);
+      return HeadersParser.toStringAsIs(headers);
     }
     const obj = {};
     headers.forEach((header) => {

--- a/test/HeadersParser.test.js
+++ b/test/HeadersParser.test.js
@@ -258,6 +258,21 @@ describe('HeadersParser', () => {
       const newValue = result[0].value;
       assert.equal(newValue, 'replaced');
     });
+
+    it('should replace header value and not remove empty headers', () => {
+      let headers = 'x-test: value 1, value 2\n';
+      headers += 'content-type: text/html; charset=ISO-8859-4\n';
+      headers += 'x-test-2: v1\n';
+      headers += 'x-test-2: v2\n';
+      headers += 'empty:';
+
+      headers = /** @type string */ (HeadersParser.replace(
+        headers,
+        'content-type',
+        'application/json'
+      ));
+      assert.notEqual(headers.indexOf('empty'), -1);
+    });
   });
 
   describe('getError()', () => {


### PR DESCRIPTION
When calling `replace()`, empty headers would be removed. When replacing, we should not be considering what headers to remove. So I added the `toStringAsIs()` method for this purpose.